### PR TITLE
add failing test for when parameters are deleted

### DIFF
--- a/pytest_commander/runner.py
+++ b/pytest_commander/runner.py
@@ -119,7 +119,7 @@ class PyTestRunner:
         run_tree = eventlet_utils.get_queue_noblock(result_queue)
         LOGGER.debug("got run_tree %s", run_tree)
 
-        self.result_tree.merge(run_tree)
+        self.result_tree.merge(run_tree, test_nodeid)
         node = self._node_index[test_nodeid]
         if node.status == result_tree.TestState.INIT:
             node.status = result_tree.TestState.RUNNING
@@ -191,7 +191,9 @@ class PyTestRunner:
     def _handle_file_update(self, filepath: str):
         """Handle a file being created or modified."""
         root_node = plugin.collect_path(filepath, self._directory)
-        self.result_tree.merge(root_node)
+        self.result_tree.merge(
+            root_node, nodeid.Nodeid.from_path(filepath, self._directory)
+        )
         self._send_update()
 
     def _handle_file_deleted(self, filepath: str):
@@ -213,7 +215,9 @@ class PyTestRunner:
             LOGGER.debug("could not find node in tree: %s", orig_nodeid)
             return
         collect_root = plugin.collect_path(dest_path, self._directory)
-        self.result_tree.merge(collect_root)
+        self.result_tree.merge(
+            collect_root, nodeid.Nodeid.from_path(dest_path, self._directory)
+        )
         self._send_update()
 
     def _pop_node(self, pop_nodeid: nodeid.Nodeid) -> result_tree.Node:

--- a/tests/snapshots/snap_test_result_tree.py
+++ b/tests/snapshots/snap_test_result_tree.py
@@ -118,26 +118,36 @@ snapshots['test_parameterized_tests_removed before_merge'] = {
                     'child_branches': {
                         'test_params.py': {
                             'child_branches': {
-                            },
-                            'child_leaves': {
-                                'test_params[alpha]': {
-                                    'longrepr': None,
-                                    'nodeid': 'path/to/test_params.py::test_params[alpha]',
-                                    'short_id': 'test_params[alpha]',
-                                    'status': 'init'
-                                },
-                                'test_params[beta]': {
-                                    'longrepr': None,
-                                    'nodeid': 'path/to/test_params.py::test_params[beta]',
-                                    'short_id': 'test_params[beta]',
-                                    'status': 'init'
-                                },
-                                'test_params[gamma]': {
-                                    'longrepr': None,
-                                    'nodeid': 'path/to/test_params.py::test_params[gamma]',
-                                    'short_id': 'test_params[gamma]',
+                                'test_params': {
+                                    'child_branches': {
+                                    },
+                                    'child_leaves': {
+                                        'alpha': {
+                                            'longrepr': None,
+                                            'nodeid': 'path/to/test_params.py::test_params[alpha]',
+                                            'short_id': 'alpha',
+                                            'status': 'init'
+                                        },
+                                        'beta': {
+                                            'longrepr': None,
+                                            'nodeid': 'path/to/test_params.py::test_params[beta]',
+                                            'short_id': 'beta',
+                                            'status': 'init'
+                                        },
+                                        'gamma': {
+                                            'longrepr': None,
+                                            'nodeid': 'path/to/test_params.py::test_params[gamma]',
+                                            'short_id': 'gamma',
+                                            'status': 'init'
+                                        }
+                                    },
+                                    'environment_state': 'inactive',
+                                    'nodeid': 'path/to/test_params.py::test_params',
+                                    'short_id': 'test_params',
                                     'status': 'init'
                                 }
+                            },
+                            'child_leaves': {
                             },
                             'environment_state': 'inactive',
                             'nodeid': 'path/to/test_params.py',
@@ -177,20 +187,30 @@ snapshots['test_parameterized_tests_removed after_merge'] = {
                     'child_branches': {
                         'test_params.py': {
                             'child_branches': {
-                            },
-                            'child_leaves': {
-                                'test_params[alpha]': {
-                                    'longrepr': None,
-                                    'nodeid': 'path/to/test_params.py::test_params[alpha]',
-                                    'short_id': 'test_params[alpha]',
-                                    'status': 'init'
-                                },
-                                'test_params[beta]': {
-                                    'longrepr': None,
-                                    'nodeid': 'path/to/test_params.py::test_params[beta]',
-                                    'short_id': 'test_params[beta]',
+                                'test_params': {
+                                    'child_branches': {
+                                    },
+                                    'child_leaves': {
+                                        'alpha': {
+                                            'longrepr': None,
+                                            'nodeid': 'path/to/test_params.py::test_params[alpha]',
+                                            'short_id': 'alpha',
+                                            'status': 'init'
+                                        },
+                                        'beta': {
+                                            'longrepr': None,
+                                            'nodeid': 'path/to/test_params.py::test_params[beta]',
+                                            'short_id': 'beta',
+                                            'status': 'init'
+                                        }
+                                    },
+                                    'environment_state': 'inactive',
+                                    'nodeid': 'path/to/test_params.py::test_params',
+                                    'short_id': 'test_params',
                                     'status': 'init'
                                 }
+                            },
+                            'child_leaves': {
                             },
                             'environment_state': 'inactive',
                             'nodeid': 'path/to/test_params.py',

--- a/tests/snapshots/snap_test_result_tree.py
+++ b/tests/snapshots/snap_test_result_tree.py
@@ -81,3 +81,115 @@ snapshots['test_build_tree 1'] = {
     'short_id': 'root',
     'status': 'init'
 }
+
+snapshots['test_parameterized_tests_removed before_merge'] = {
+    'child_branches': {
+        'path': {
+            'child_branches': {
+                'to': {
+                    'child_branches': {
+                        'test_params.py': {
+                            'child_branches': {
+                            },
+                            'child_leaves': {
+                                'test_params[alpha]': {
+                                    'longrepr': None,
+                                    'nodeid': 'path/to/test_params.py::test_params[alpha]',
+                                    'short_id': 'test_params[alpha]',
+                                    'status': 'init'
+                                },
+                                'test_params[beta]': {
+                                    'longrepr': None,
+                                    'nodeid': 'path/to/test_params.py::test_params[beta]',
+                                    'short_id': 'test_params[beta]',
+                                    'status': 'init'
+                                },
+                                'test_params[gamma]': {
+                                    'longrepr': None,
+                                    'nodeid': 'path/to/test_params.py::test_params[gamma]',
+                                    'short_id': 'test_params[gamma]',
+                                    'status': 'init'
+                                }
+                            },
+                            'environment_state': 'inactive',
+                            'nodeid': 'path/to/test_params.py',
+                            'short_id': 'test_params.py',
+                            'status': 'init'
+                        }
+                    },
+                    'child_leaves': {
+                    },
+                    'environment_state': 'inactive',
+                    'nodeid': 'path/to',
+                    'short_id': 'to',
+                    'status': 'init'
+                }
+            },
+            'child_leaves': {
+            },
+            'environment_state': 'inactive',
+            'nodeid': 'path',
+            'short_id': 'path',
+            'status': 'init'
+        }
+    },
+    'child_leaves': {
+    },
+    'environment_state': 'inactive',
+    'nodeid': '',
+    'short_id': 'root',
+    'status': 'init'
+}
+
+snapshots['test_parameterized_tests_removed after_merge'] = {
+    'child_branches': {
+        'path': {
+            'child_branches': {
+                'to': {
+                    'child_branches': {
+                        'test_params.py': {
+                            'child_branches': {
+                            },
+                            'child_leaves': {
+                                'test_params[alpha]': {
+                                    'longrepr': None,
+                                    'nodeid': 'path/to/test_params.py::test_params[alpha]',
+                                    'short_id': 'test_params[alpha]',
+                                    'status': 'init'
+                                },
+                                'test_params[beta]': {
+                                    'longrepr': None,
+                                    'nodeid': 'path/to/test_params.py::test_params[beta]',
+                                    'short_id': 'test_params[beta]',
+                                    'status': 'init'
+                                }
+                            },
+                            'environment_state': 'inactive',
+                            'nodeid': 'path/to/test_params.py',
+                            'short_id': 'test_params.py',
+                            'status': 'init'
+                        }
+                    },
+                    'child_leaves': {
+                    },
+                    'environment_state': 'inactive',
+                    'nodeid': 'path/to',
+                    'short_id': 'to',
+                    'status': 'init'
+                }
+            },
+            'child_leaves': {
+            },
+            'environment_state': 'inactive',
+            'nodeid': 'path',
+            'short_id': 'path',
+            'status': 'init'
+        }
+    },
+    'child_leaves': {
+    },
+    'environment_state': 'inactive',
+    'nodeid': '',
+    'short_id': 'root',
+    'status': 'init'
+}

--- a/tests/test_result_tree.py
+++ b/tests/test_result_tree.py
@@ -30,3 +30,28 @@ def test_build_tree(snapshot):
     serializer = result_tree.BranchNodeSchema()
     serialized_tree = serializer.dump(tree)
     snapshot.assert_match(serialized_tree)
+
+
+def test_parameterized_tests_removed(snapshot):
+    items = [
+        SessionItem(nodeid)
+        for nodeid in [
+            "path/to/test_params.py::test_params[alpha]",
+            "path/to/test_params.py::test_params[beta]",
+            "path/to/test_params.py::test_params[gamma]",
+        ]
+    ]
+
+    items_missing_one_parameter = items[:2]
+    tree = result_tree.build_from_items(items, "/root")
+    tree_missing_one_parameter = result_tree.build_from_items(
+        items_missing_one_parameter, "/root"
+    )
+    assert len(items) == 3
+    assert len(items_missing_one_parameter) == 2
+    serializer = result_tree.BranchNodeSchema()
+    serialized_tree = serializer.dump(tree)
+    tree.merge(tree_missing_one_parameter)
+    serialized_tree_after_merge = serializer.dump(tree)
+    snapshot.assert_match(serialized_tree, "before_merge")
+    snapshot.assert_match(serialized_tree_after_merge, "after_merge")

--- a/tests/test_result_tree.py
+++ b/tests/test_result_tree.py
@@ -7,6 +7,7 @@ import os
 import pytest
 
 from pytest_commander import result_tree
+from pytest_commander import nodeid
 
 SessionItem = collections.namedtuple("SessionItem", ["nodeid"])
 
@@ -54,7 +55,10 @@ def test_parameterized_tests_removed(snapshot):
     assert len(items_missing_one_parameter) == 2
     serializer = result_tree.BranchNodeSchema()
     serialized_tree = serializer.dump(tree)
-    tree.merge(tree_missing_one_parameter)
+    tree.merge(
+        tree_missing_one_parameter,
+        nodeid.Nodeid.from_string("path/to/test_params.py"),
+    )
     serialized_tree_after_merge = serializer.dump(tree)
     snapshot.assert_match(serialized_tree, "before_merge")
     snapshot.assert_match(serialized_tree_after_merge, "after_merge")


### PR DESCRIPTION
this adds a unit test (which fails currently) to assert that when
the watched test suite has a parameter removed, the BranchNode.merge
method also removes it from its tree.